### PR TITLE
Fix column header display

### DIFF
--- a/app/components/SensorTable.tsx
+++ b/app/components/SensorTable.tsx
@@ -75,6 +75,7 @@ function pivotData(records: ParameterRecord[]) {
       return {
         field,
         headerName: `${plant} / ${machine} / ${source}`,
+        renderHeader: () => source,
         width: 120,
       };
     }),


### PR DESCRIPTION
## Summary
- show only the data source name in the table's column headers
- keep full hierarchical path in the Columns panel

## Testing
- `npm run lint` *(fails: `next` not found)*