### PR TITLE
Fix DataGrid CSV export encoding

### DIFF
--- a/app/components/SensorTable.tsx
+++ b/app/components/SensorTable.tsx
@@ -128,6 +128,11 @@ export default function SensorTable() {
           pinnedColumns: { left: ['param_name_en', 'param_name_ja'] },
         }}
         showToolbar
+        slotProps={{
+          toolbar: {
+            csvOptions: { utf8WithBom: true },
+          },
+        }}
       />
     </Box>
   );


### PR DESCRIPTION
## Summary
- fix CSV export encoding on the SensorTable

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: `next` not found)*