### PR TITLE
Add UNIT TAG master title and responsive sensor table

### DIFF
--- a/app/components/SensorTable.tsx
+++ b/app/components/SensorTable.tsx
@@ -119,7 +119,7 @@ export default function SensorTable() {
   }, []);
 
   return (
-    <Box sx={{ height: 750, width: '100%', padding: 2 }}>
+    <Box sx={{ height: '100%', width: '100%', padding: 2 }}>
       <DataGrid
         rows={rows}
         columns={columns}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,8 +2,11 @@ import SensorTable from './components/SensorTable';
 
 export default function Home() {
   return (
-    <main className="p-4">
-      <SensorTable />
+    <main className="flex flex-col h-screen p-4">
+      <h1 className="text-xl font-bold mb-4">UNIT TAG マスター</h1>
+      <div className="flex-grow min-h-0">
+        <SensorTable />
+      </div>
     </main>
   );
 }


### PR DESCRIPTION
## Summary
- add a heading to the sensor table page
- make the page layout fill the viewport
- let the SensorTable component stretch to available space

## Testing
- `npm run lint` *(fails: `next` not found)*