### PR TITLE
Add sidebar navigation with blank page

### DIFF
--- a/app/components/Sidebar.tsx
+++ b/app/components/Sidebar.tsx
@@ -1,0 +1,30 @@
+'use client';
+
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+
+const menuItems = [
+  { href: '/', label: 'ユニットタグマスター' },
+  { href: '/data-selection', label: 'データ選択' },
+];
+
+export default function Sidebar() {
+  const pathname = usePathname();
+  return (
+    <aside className="w-64 bg-gray-100 dark:bg-gray-900 p-4">
+      <nav className="space-y-2">
+        {menuItems.map((item) => (
+          <Link
+            key={item.href}
+            href={item.href}
+            className={`block px-3 py-2 rounded hover:bg-gray-200 dark:hover:bg-gray-700 ${
+              pathname === item.href ? 'font-bold text-blue-600' : ''
+            }`}
+          >
+            {item.label}
+          </Link>
+        ))}
+      </nav>
+    </aside>
+  );
+}

--- a/app/data-selection/page.tsx
+++ b/app/data-selection/page.tsx
@@ -1,0 +1,8 @@
+export default function DataSelection() {
+  return (
+    <div className="p-4">
+      <h1 className="text-xl font-bold mb-4">データ選択</h1>
+      <p>Coming soon...</p>
+    </div>
+  );
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,6 +3,7 @@ import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import MuiXLicense from "./components/MuiXLicense";
+import Sidebar from "./components/Sidebar";
 
 
 
@@ -32,7 +33,10 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
-        {children}
+        <div className="flex h-screen">
+          <Sidebar />
+          <main className="flex-grow overflow-auto">{children}</main>
+        </div>
         <MuiXLicense />
       </body>
     </html>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,11 +2,11 @@ import SensorTable from './components/SensorTable';
 
 export default function Home() {
   return (
-    <main className="flex flex-col h-screen p-4">
+    <div className="flex flex-col h-full p-4">
       <h1 className="text-xl font-bold mb-4">UNIT TAG マスター</h1>
       <div className="flex-grow min-h-0">
         <SensorTable />
       </div>
-    </main>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
- add a sidebar component with links
- update layout to show the sidebar
- adjust the home page to fit inside the new layout
- create a placeholder `データ選択` page

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npx tsc --noEmit` *(fails: cannot find modules)*
- `npm run build` *(fails: `next` not found)*