### PR TITLE
Add event selection UI

### DIFF
--- a/app/api/events/route.ts
+++ b/app/api/events/route.ts
@@ -1,0 +1,18 @@
+import data from '@/data/event_master.json';
+import { NextResponse } from 'next/server';
+
+const API_URL = 'http://127.0.0.1:8000/events';
+
+export async function GET() {
+  try {
+    const response = await fetch(API_URL, { next: { revalidate: 60 } });
+    if (!response.ok) {
+      throw new Error(`FastAPI request failed with status ${response.status}`);
+    }
+    const data = await response.json();
+    return NextResponse.json(data);
+  } catch (error) {
+    console.error('Error fetching events:', error);
+    return NextResponse.json(data, { status: 200 });
+  }
+}

--- a/app/components/EventTable.tsx
+++ b/app/components/EventTable.tsx
@@ -1,0 +1,55 @@
+'use client';
+import dynamic from 'next/dynamic';
+import { Box } from '@mui/material';
+import { GridColDef } from '@mui/x-data-grid-premium';
+import { useEffect, useState } from 'react';
+
+const DataGrid = dynamic(() => import('@mui/x-data-grid-premium').then(m => m.DataGridPremium), { ssr: false });
+
+type EventRecord = {
+  id: number;
+  plant_name: string;
+  machine_no: string;
+  label: string;
+  label_description: string;
+  event: string;
+  event_detail: string;
+  start_time: string;
+  end_time: string;
+};
+
+type Props = {
+  onSelectionChange?: (ids: (string | number)[]) => void;
+};
+
+export default function EventTable({ onSelectionChange }: Props) {
+  const [rows, setRows] = useState<EventRecord[]>([]);
+  const [columns] = useState<GridColDef[]>([
+    { field: 'plant_name', headerName: 'plant', width: 100 },
+    { field: 'machine_no', headerName: 'machine', width: 100 },
+    { field: 'label', headerName: 'label', width: 100 },
+    { field: 'label_description', headerName: 'label desc', width: 160 },
+    { field: 'event', headerName: 'event', width: 120 },
+    { field: 'event_detail', headerName: 'event detail', width: 160 },
+    { field: 'start_time', headerName: 'start', width: 170 },
+    { field: 'end_time', headerName: 'end', width: 170 },
+  ]);
+
+  useEffect(() => {
+    fetch('/api/events')
+      .then(res => res.json())
+      .then(setRows)
+      .catch(err => console.error(err));
+  }, []);
+
+  return (
+    <Box sx={{ height: 300, width: '100%' }}>
+      <DataGrid
+        rows={rows}
+        columns={columns}
+        checkboxSelection
+        onRowSelectionModelChange={onSelectionChange}
+      />
+    </Box>
+  );
+}

--- a/app/data-selection/page.tsx
+++ b/app/data-selection/page.tsx
@@ -1,8 +1,90 @@
+'use client';
+import { useState } from 'react';
+import EventTable from '../components/EventTable';
+import { Button, TextField } from '@mui/material';
+
+interface ManualCondition {
+  plant_name: string;
+  machine_no: string;
+  start_time: string;
+  end_time: string;
+}
+
 export default function DataSelection() {
+  const [selectedEvents, setSelectedEvents] = useState<(string | number)[]>([]);
+  const [conditions, setConditions] = useState<ManualCondition[]>([
+    { plant_name: '', machine_no: '', start_time: '', end_time: '' },
+  ]);
+
+  const handleAddCondition = () => {
+    setConditions([...conditions, { plant_name: '', machine_no: '', start_time: '', end_time: '' }]);
+  };
+
+  const handleChange = (index: number, field: keyof ManualCondition, value: string) => {
+    const updated = [...conditions];
+    updated[index][field] = value;
+    setConditions(updated);
+  };
+
+  const handleFetch = () => {
+    console.log('selected events', selectedEvents);
+    console.log('manual conditions', conditions);
+    alert('条件をコンソールに出力しました');
+  };
+
   return (
-    <div className="p-4">
-      <h1 className="text-xl font-bold mb-4">データ選択</h1>
-      <p>Coming soon...</p>
+    <div className="p-4 space-y-6">
+      <h1 className="text-xl font-bold">データ選択</h1>
+
+      <section>
+        <h2 className="text-lg font-semibold mb-2">① イベントから選択</h2>
+        <EventTable onSelectionChange={setSelectedEvents} />
+      </section>
+
+      <section>
+        <h2 className="text-lg font-semibold mb-2">② 自分で指定</h2>
+        <div className="space-y-2">
+          {conditions.map((c, i) => (
+            <div key={i} className="flex space-x-2">
+              <TextField
+                label="plant"
+                size="small"
+                value={c.plant_name}
+                onChange={e => handleChange(i, 'plant_name', e.target.value)}
+              />
+              <TextField
+                label="machine"
+                size="small"
+                value={c.machine_no}
+                onChange={e => handleChange(i, 'machine_no', e.target.value)}
+              />
+              <TextField
+                label="start_time"
+                type="datetime-local"
+                size="small"
+                value={c.start_time}
+                onChange={e => handleChange(i, 'start_time', e.target.value)}
+                InputLabelProps={{ shrink: true }}
+              />
+              <TextField
+                label="end_time"
+                type="datetime-local"
+                size="small"
+                value={c.end_time}
+                onChange={e => handleChange(i, 'end_time', e.target.value)}
+                InputLabelProps={{ shrink: true }}
+              />
+            </div>
+          ))}
+          <Button variant="outlined" size="small" onClick={handleAddCondition}>
+            条件追加
+          </Button>
+        </div>
+      </section>
+
+      <Button variant="contained" onClick={handleFetch}>
+        データ取得
+      </Button>
     </div>
   );
 }

--- a/data/event_master.json
+++ b/data/event_master.json
@@ -1,0 +1,35 @@
+[
+  {
+    "id": 1,
+    "plant_name": "PlantA",
+    "machine_no": "Machine1",
+    "label": "L001",
+    "label_description": "温度異常",
+    "event": "Overheat",
+    "event_detail": "Machine exceeded 80C",
+    "start_time": "2024-06-01T10:00:00Z",
+    "end_time": "2024-06-01T10:30:00Z"
+  },
+  {
+    "id": 2,
+    "plant_name": "PlantA",
+    "machine_no": "Machine2",
+    "label": "L002",
+    "label_description": "圧力低下",
+    "event": "LowPressure",
+    "event_detail": "Pressure below threshold",
+    "start_time": "2024-06-02T12:00:00Z",
+    "end_time": "2024-06-02T12:45:00Z"
+  },
+  {
+    "id": 3,
+    "plant_name": "PlantB",
+    "machine_no": "Machine1",
+    "label": "L003",
+    "label_description": "振動過大",
+    "event": "HighVibration",
+    "event_detail": "Vibration level too high",
+    "start_time": "2024-06-03T09:00:00Z",
+    "end_time": "2024-06-03T09:20:00Z"
+  }
+]


### PR DESCRIPTION
## Summary
- implement UI for choosing events or specifying conditions
- add EventTable component with checkbox selection
- show data in `data-selection` page and handle manual conditions
- include sample `event_master.json` data
- add `/api/events` route

## Testing
- `npm run lint` *(fails: `next` not found)*